### PR TITLE
fix timestamp used for requests to be in nanoseconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ## Building
 to build you need to have a recent version of Go installed, go into apitool`s directory and type:
 
-`go build -o apitool gitlab.qredo.com/qredo-server/apitool/cmd/cli`
+`go build -o apitool github.com/qredo/apitool/cmd/cli`
 
 this will produce a binary called `apitool`
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ## Building
 to build you need to have a recent version of Go installed, go into apitool`s directory and type:
 
-`go build -o apitool github.com/qredo/apitool/cmd/cli`
+`go build -o apitool gitlab.qredo.com/qredo-server/apitool/cmd/cli`
 
 this will produce a binary called `apitool`
 

--- a/cmd/cli/climain.go
+++ b/cmd/cli/climain.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"time"
 
-	"gitlab.qredo.com/qredo-server/apitool/defs"
-	"gitlab.qredo.com/qredo-server/apitool/webui"
+	"github.com/qredo/apitool/defs"
+	"github.com/qredo/apitool/webui"
 
 	"github.com/pkg/errors"
 )

--- a/cmd/cli/climain.go
+++ b/cmd/cli/climain.go
@@ -44,7 +44,7 @@ func setupRequest(req *defs.Request) error {
 	if *flagTimestamp != "" {
 		req.Timestamp = strings.TrimSpace(*flagTimestamp)
 	} else {
-		req.Timestamp = fmt.Sprintf("%v", time.Now().Unix())
+		req.Timestamp = fmt.Sprintf("%v", time.Now().UnixNano())
 	}
 
 	req.ApiKey = strings.TrimSpace(*flagAPIKey)

--- a/cmd/cli/climain.go
+++ b/cmd/cli/climain.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/qredo/apitool/defs"
-	"github.com/qredo/apitool/webui"
+	"gitlab.qredo.com/qredo-server/apitool/defs"
+	"gitlab.qredo.com/qredo-server/apitool/webui"
 
 	"github.com/pkg/errors"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/qredo/apitool
+module gitlab.qredo.com/qredo-server/apitool
 
 go 1.17
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gitlab.qredo.com/qredo-server/apitool
+module github.com/qredo/apitool
 
 go 1.17
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/qredo/apitool
 
-go 1.17
+go 1.19
 
 require (
 	github.com/gin-contrib/cors v1.3.1

--- a/webui/handlers.go
+++ b/webui/handlers.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/qredo/apitool/defs"
+	"gitlab.qredo.com/qredo-server/apitool/defs"
 
 	"github.com/pkg/errors"
 

--- a/webui/handlers.go
+++ b/webui/handlers.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"gitlab.qredo.com/qredo-server/apitool/defs"
+	"github.com/qredo/apitool/defs"
 
 	"github.com/pkg/errors"
 

--- a/webui/handlers.go
+++ b/webui/handlers.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -69,7 +69,7 @@ func Send(c *gin.Context) {
 
 func processRequest(c *gin.Context) (*defs.Request, error) {
 	wsRequest := &webSignRequest{}
-	body, err := ioutil.ReadAll(c.Request.Body)
+	body, err := io.ReadAll(c.Request.Body)
 	if err != nil {
 		return nil, errors.New("body")
 	}
@@ -79,7 +79,7 @@ func processRequest(c *gin.Context) (*defs.Request, error) {
 	}
 
 	req := &defs.Request{
-		Timestamp: fmt.Sprintf("%v", time.Now().Unix()),
+		Timestamp: fmt.Sprintf("%v", time.Now().UnixNano()),
 		Method:    wsRequest.Method,
 		URL:       strings.TrimSpace(wsRequest.URL),
 		ApiKey:    strings.TrimSpace(wsRequest.ApiKey),

--- a/webui/http.go
+++ b/webui/http.go
@@ -9,9 +9,9 @@ import (
 )
 
 func Serve(port string) {
-	gin.SetMode(gin.ReleaseMode)
 	router := gin.Default()
 	router.Use(cors.Default())
+	gin.SetMode(gin.ReleaseMode)
 
 	router.GET("/", GetIndex)
 	router.POST("/sign", Sign)


### PR DESCRIPTION
* When using the tool and trying to make more than one request per second with a regular second based timestamp it get's invalidated with the first use. By using UnixNano() the problem is resolved
* bump go version to 1.19
* change the deprecated ioutil.ReadFile to io.ReadFile
* set gin Release mode after the router has been created